### PR TITLE
add return keyword & exec() built-in function

### DIFF
--- a/constructors.go
+++ b/constructors.go
@@ -134,6 +134,10 @@ func (t *Template) newInclude(pos Pos, line int, name, pipe Expression) *Include
 	return &IncludeNode{NodeBase: NodeBase{TemplateName: t.Name, NodeType: NodeInclude, Pos: pos, Line: line}, Name: name, Expression: pipe}
 }
 
+func (t *Template) newReturn(pos Pos, line int, pipe Expression) *ReturnNode {
+	return &ReturnNode{NodeBase: NodeBase{TemplateName: t.Name, NodeType: NodeReturn, Pos: pos, Line: line}, Value: pipe}
+}
+
 func (t *Template) newNumber(pos Pos, text string, typ itemType) (*NumberNode, error) {
 	n := &NumberNode{NodeBase: NodeBase{TemplateName: t.Name, NodeType: NodeNumber, Pos: pos}, Text: text}
 	// todo: optimize

--- a/lex.go
+++ b/lex.go
@@ -87,6 +87,7 @@ const (
 	itemExtends
 	itemBlock
 	itemYield
+	itemReturn
 	itemContent
 	itemInclude
 	itemElse
@@ -109,6 +110,7 @@ var key = map[string]itemType{
 	"include": itemInclude,
 	"block":   itemBlock,
 	"yield":   itemYield,
+	"return": itemReturn,
 
 	"else": itemElse,
 	"end":  itemEnd,

--- a/node.go
+++ b/node.go
@@ -89,6 +89,7 @@ const (
 	NodeInclude
 	NodeYield
 	NodeSet
+	NodeReturn
 	beginExpressions
 	NodeString //A string constant.
 	NodeNil    //An untyped nil constant.
@@ -663,4 +664,14 @@ func (s *SliceExprNode) String() string {
 		len_string = s.EndIndex.String()
 	}
 	return fmt.Sprintf("%s[%s:%s]", s.Base, index_string, len_string)
+}
+
+
+type ReturnNode struct {
+	NodeBase
+	Value Expression
+}
+
+func (n *ReturnNode) String() string {
+	return fmt.Sprintf("return %v", n.Value)
 }

--- a/parse.go
+++ b/parse.go
@@ -431,6 +431,12 @@ func (t *Template) parseInclude() Node {
 	return t.newInclude(name.Position(), t.lex.lineNumber(), name, pipe)
 }
 
+func (t *Template) parseReturn() Node {
+	value := t.expression("return")
+	t.expect(itemRightDelim, "return")
+	return t.newReturn(value.Position(), t.lex.lineNumber(), value)
+}
+
 // itemListBlock:
 //	textOrAction*
 // Terminates at {{end}} or {{else}}, returned separately.
@@ -497,6 +503,8 @@ func (t *Template) action() (n Node) {
 		return t.parseInclude()
 	case itemYield:
 		return t.parseYield()
+	case itemReturn:
+		return t.parseReturn()
 	}
 
 	t.backup()


### PR DESCRIPTION
This will allow returning a value from a template and using that value in the calling template, enabling users to have "function" templates they can reuse.

foo.jet:
```
{{ f := "f" }}
{{ o := "o" }}

...some content that will be discarded when this template runs inside exec() ...

{{ return f+o+o }}
```

test.jet:
```
{{ foo := exec("./foo") }}

<p>below the line, there will only be "foo":</p>
<hr>
{{ foo }}
```